### PR TITLE
Add Phinx migration tooling

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,16 @@
+# Backend
+
+## Database Migrations
+
+Generate a new migration:
+
+```
+vendor/bin/phinx create CreateUsersTable
+```
+
+Run pending migrations:
+
+```
+vendor/bin/phinx migrate
+```
+

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -3,11 +3,16 @@
     "slim/slim": "^4.15",
     "slim/psr7": "^1.7",
     "illuminate/database": "^10.0",
-    "vlucas/phpdotenv": "^5.6"
+    "vlucas/phpdotenv": "^5.6",
+    "robmorgan/phinx": "^0.14"
   },
   "autoload": {
     "psr-4": {
       "App\\": "src/"
     }
+  },
+  "scripts": {
+    "migrate": "vendor/bin/phinx migrate",
+    "rollback": "vendor/bin/phinx rollback"
   }
 }

--- a/backend/phinx.php
+++ b/backend/phinx.php
@@ -1,0 +1,29 @@
+<?php
+
+use Dotenv\Dotenv;
+
+require __DIR__ . '/vendor/autoload.php';
+
+if (file_exists(__DIR__ . '/.env')) {
+    Dotenv::createImmutable(__DIR__)->load();
+}
+
+return [
+    'paths' => [
+        'migrations' => __DIR__ . '/database/migrations',
+    ],
+    'environments' => [
+        'default_migration_table' => 'phinxlog',
+        'default_environment' => 'development',
+        'development' => [
+            'adapter' => 'mysql',
+            'host' => getenv('DB_HOST'),
+            'name' => getenv('DB_DATABASE'),
+            'user' => getenv('DB_USERNAME'),
+            'pass' => getenv('DB_PASSWORD'),
+            'port' => getenv('DB_PORT') ?: 3306,
+            'charset' => 'utf8mb4',
+        ],
+    ],
+];
+


### PR DESCRIPTION
## Summary
- add Phinx dependency and scripts to composer configuration
- introduce Phinx configuration file using environment variables
- document migration commands and create migrations directory

## Testing
- `composer install`
- `php -l phinx.php`
- `vendor/bin/phinx -V`


------
https://chatgpt.com/codex/tasks/task_e_68ad5a2805a4832084dc28dc4e5a3baf