### PR TITLE
Add roles table and seed, link users with roles

### DIFF
--- a/backend/src/config/knexfile.ts
+++ b/backend/src/config/knexfile.ts
@@ -21,6 +21,10 @@ const config: { [key: string]: Knex.Config } = {
       directory: "../db/migrations",
       extension: "ts",
     },
+    seeds: {
+      directory: "../db/seeds",
+      extension: "ts",
+    },
   },
 };
 

--- a/backend/src/db/migrations/20250826091257_create_roles.ts
+++ b/backend/src/db/migrations/20250826091257_create_roles.ts
@@ -1,0 +1,12 @@
+import { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.createTable("roles", (table) => {
+    table.increments("id").primary();
+    table.string("name", 50).notNullable().unique();
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.dropTableIfExists("roles");
+}

--- a/backend/src/db/migrations/20250826091258_add_role_id_to_users.ts
+++ b/backend/src/db/migrations/20250826091258_add_role_id_to_users.ts
@@ -1,0 +1,18 @@
+import { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema.alterTable("users", (table) => {
+    table
+      .integer("role_id")
+      .notNullable()
+      .references("id")
+      .inTable("roles")
+      .defaultTo(3);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema.alterTable("users", (table) => {
+    table.dropColumn("role_id");
+  });
+}

--- a/backend/src/db/seeds/01_roles.ts
+++ b/backend/src/db/seeds/01_roles.ts
@@ -1,0 +1,10 @@
+import { Knex } from "knex";
+
+export async function seed(knex: Knex): Promise<void> {
+  await knex("roles").del();
+  await knex("roles").insert([
+    { name: "admin" },
+    { name: "user" },
+    { name: "client" },
+  ]);
+}

--- a/backend/src/modules/users/user.service.ts
+++ b/backend/src/modules/users/user.service.ts
@@ -33,7 +33,11 @@ export async function createUser(dto: CreateUserDTO): Promise<UserDTO> {
   const exists = await repo.findByEmail(dto.email);
   if (exists) throw new Error("email already in use");
   const hash = await bcrypt.hash(dto.password, 10);
-  const created = await repo.create({ ...dto, password: hash });
+  const created = await repo.create({
+    ...dto,
+    password: hash,
+    role_id: dto.role_id ?? 3,
+  });
   return sanitize(created);
 }
 

--- a/backend/src/modules/users/user.types.ts
+++ b/backend/src/modules/users/user.types.ts
@@ -4,6 +4,7 @@ export interface User {
   surname: string;
   email: string;
   password: string; // хранится уже hash
+  role_id: number;
   created_at?: Date;
   updated_at?: Date;
 }
@@ -13,6 +14,7 @@ export interface CreateUserDTO {
   surname: string;
   email: string;
   password: string; // raw
+  role_id?: number;
 }
 
 export interface UpdateUserDTO {
@@ -20,6 +22,7 @@ export interface UpdateUserDTO {
   surname?: string;
   email?: string;
   password?: string; // raw
+  role_id?: number;
 }
 
 export type UserDTO = Omit<User, "password">;


### PR DESCRIPTION
## Summary
- add roles table and seeding for `admin`, `user`, `client`
- link users to roles via `role_id` with default to client
- configure knex seeds and expose role handling in user types/service

## Testing
- `cd backend && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad8e6eec988320b19ceebe73a3d0f6