### PR TITLE
Add JWT-based authentication and role protection

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,8 @@
+PORT=3300
+DB_HOST=127.0.0.1
+DB_PORT=5432
+DB_USER=app_user
+DB_PASSWORD=secret
+DB_NAME=app_db
+JWT_SECRET=supersecret
+JWT_EXPIRES_IN=1h

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,12 +12,14 @@
         "bcryptjs": "^3.0.2",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
+        "jsonwebtoken": "^9.0.2",
         "knex": "^3.1.0",
         "pg": "^8.12.0"
       },
       "devDependencies": {
         "@types/bcryptjs": "^2.4.6",
         "@types/express": "^4.17.21",
+        "@types/jsonwebtoken": "^9.0.10",
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.4.5"
@@ -153,10 +155,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
     },
@@ -363,6 +383,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -571,6 +597,15 @@
       "license": "MIT",
       "dependencies": {
         "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/ee-first": {
@@ -1025,6 +1060,55 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/knex": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/knex/-/knex-3.1.0.tgz",
@@ -1103,6 +1187,48 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/make-error": {
@@ -1599,6 +1725,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "0.19.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,20 +9,22 @@
     "migrate": "knex migrate:latest --knexfile src/config/knexfile.ts",
     "rollback": "knex migrate:rollback --knexfile src/config/knexfile.ts"
   },
-  "dependencies": {
-    "bcryptjs": "^3.0.2",
-    "dotenv": "^16.4.5",
-    "express": "^4.19.2",
-    "knex": "^3.1.0",
-    "pg": "^8.12.0"
-  },
-  "devDependencies": {
-    "@types/bcryptjs": "^2.4.6",
-    "@types/express": "^4.17.21",
-    "ts-node": "^10.9.2",
-    "ts-node-dev": "^2.0.0",
-    "typescript": "^5.4.5"
-  },
+    "dependencies": {
+      "bcryptjs": "^3.0.2",
+      "dotenv": "^16.4.5",
+      "express": "^4.19.2",
+      "jsonwebtoken": "^9.0.2",
+      "knex": "^3.1.0",
+      "pg": "^8.12.0"
+    },
+    "devDependencies": {
+      "@types/bcryptjs": "^2.4.6",
+      "@types/express": "^4.17.21",
+      "@types/jsonwebtoken": "^9.0.10",
+      "ts-node": "^10.9.2",
+      "ts-node-dev": "^2.0.0",
+      "typescript": "^5.4.5"
+    },
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,6 +2,7 @@ import express from "express";
 import dotenv from "dotenv";
 import path from "path";
 import usersRouter from "./modules/users/user.routes";
+import authRouter from "./modules/auth/auth.routes";
 import { knex } from "./db/knex";
 
 dotenv.config({ path: path.resolve(__dirname, "../.env") });
@@ -20,6 +21,7 @@ app.get("/health", async (_req, res, next) => {
 });
 
 // API
+app.use("/api/auth", authRouter);
 app.use("/api/users", usersRouter);
 
 // централизованный перехват ошибок

--- a/backend/src/lib/auth.ts
+++ b/backend/src/lib/auth.ts
@@ -1,0 +1,53 @@
+import { Request, Response, NextFunction } from "express";
+import jwt, { Secret, SignOptions } from "jsonwebtoken";
+
+export interface JwtUser {
+  id: number;
+  role: string;
+}
+
+export interface AuthRequest extends Request {
+  user?: JwtUser;
+}
+
+export function signToken(id: number, role: string) {
+  const secret: Secret = process.env.JWT_SECRET || "secret";
+  const expiresIn = process.env.JWT_EXPIRES_IN || "1h";
+  const options: SignOptions = { expiresIn: expiresIn as any };
+  return jwt.sign({ id, role }, secret, options);
+}
+
+export function authMiddleware(req: AuthRequest, res: Response, next: NextFunction) {
+  const auth = req.headers.authorization;
+  if (!auth) return res.status(401).json({ error: "unauthorized" });
+  const token = auth.split(" ")[1];
+  if (!token) return res.status(401).json({ error: "unauthorized" });
+  try {
+    const secret = process.env.JWT_SECRET || "secret";
+    const payload = jwt.verify(token, secret) as JwtUser;
+    req.user = payload;
+    next();
+  } catch (e) {
+    return res.status(401).json({ error: "invalid_token" });
+  }
+}
+
+export function requireRole(...roles: string[]) {
+  return (req: AuthRequest, res: Response, next: NextFunction) => {
+    if (!req.user || !roles.includes(req.user.role)) {
+      return res.status(403).json({ error: "forbidden" });
+    }
+    next();
+  };
+}
+
+export function requireSelfOrRole(...roles: string[]) {
+  return (req: AuthRequest, res: Response, next: NextFunction) => {
+    const id = Number(req.params.id);
+    if (!req.user) return res.status(403).json({ error: "forbidden" });
+    if (req.user.id === id || roles.includes(req.user.role)) {
+      return next();
+    }
+    return res.status(403).json({ error: "forbidden" });
+  };
+}

--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -1,0 +1,8 @@
+import { Request, Response } from "express";
+import * as service from "./auth.service";
+
+export async function login(req: Request, res: Response) {
+  const { email, password } = req.body;
+  const result = await service.login(email, password);
+  res.json(result);
+}

--- a/backend/src/modules/auth/auth.routes.ts
+++ b/backend/src/modules/auth/auth.routes.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { asyncHandler as ah } from "../../lib/asyncHandler";
+import * as ctrl from "./auth.controller";
+
+const router = Router();
+
+router.post("/login", ah(ctrl.login));
+
+export default router;

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -1,0 +1,12 @@
+import bcrypt from "bcryptjs";
+import * as usersRepo from "../users/user.repository";
+import { signToken } from "../../lib/auth";
+
+export async function login(email: string, password: string) {
+  const user = await usersRepo.findByEmailWithRole(email);
+  if (!user) throw new Error("invalid credentials");
+  const ok = await bcrypt.compare(password, user.password);
+  if (!ok) throw new Error("invalid credentials");
+  const token = signToken(user.id, user.role);
+  return { token };
+}

--- a/backend/src/modules/users/user.repository.ts
+++ b/backend/src/modules/users/user.repository.ts
@@ -11,6 +11,16 @@ export async function findByEmail(email: string): Promise<User | undefined> {
   return knex<User>(TABLE).where({ email }).first();
 }
 
+export async function findByEmailWithRole(
+  email: string
+): Promise<(User & { role: string }) | undefined> {
+  return knex<User>(TABLE)
+    .select("users.*", "roles.name as role")
+    .leftJoin("roles", "users.role_id", "roles.id")
+    .where("users.email", email)
+    .first();
+}
+
 export async function list(limit = 20, offset = 0): Promise<User[]> {
   return knex<User>(TABLE).select("*").limit(limit).offset(offset).orderBy("id", "asc");
 }

--- a/backend/src/modules/users/user.routes.ts
+++ b/backend/src/modules/users/user.routes.ts
@@ -1,13 +1,20 @@
 import { Router } from "express";
 import * as ctrl from "./user.controller";
 import { asyncHandler as ah } from "../../lib/asyncHandler";
+import {
+  authMiddleware,
+  requireRole,
+  requireSelfOrRole,
+} from "../../lib/auth";
 
 const router = Router();
 
-router.get("/", ah(ctrl.list));
-router.get("/:id", ah(ctrl.get));
-router.post("/", ah(ctrl.create));
-router.put("/:id", ah(ctrl.update));
-router.delete("/:id", ah(ctrl.remove));
+router.use(authMiddleware);
+
+router.get("/", requireRole("admin"), ah(ctrl.list));
+router.get("/:id", requireSelfOrRole("admin"), ah(ctrl.get));
+router.post("/", requireRole("admin"), ah(ctrl.create));
+router.put("/:id", requireSelfOrRole("admin"), ah(ctrl.update));
+router.delete("/:id", requireRole("admin"), ah(ctrl.remove));
 
 export default router;


### PR DESCRIPTION
## Summary
- add JWT utility and role-based middlewares
- add login route issuing tokens
- secure user routes and expose auth endpoints
- document JWT settings in `.env.example`

## Testing
- `cd backend && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ad9348ab5483208a6f4d9f7e6a6ba6