### PR TITLE
feat: add auth forms and client role protection

### DIFF
--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -1,8 +1,31 @@
 import { Request, Response } from "express";
 import * as service from "./auth.service";
+import * as usersService from "../users/user.service";
+import { AuthRequest } from "../../lib/auth";
+
+function fromBase64(str: string) {
+  return Buffer.from(str, "base64").toString("utf-8");
+}
 
 export async function login(req: Request, res: Response) {
-  const { email, password } = req.body;
+  const email = fromBase64(req.body.email);
+  const password = fromBase64(req.body.password);
   const result = await service.login(email, password);
   res.json(result);
+}
+
+export async function register(req: Request, res: Response) {
+  const dto = {
+    name: fromBase64(req.body.name),
+    surname: fromBase64(req.body.surname),
+    email: fromBase64(req.body.email),
+    password: fromBase64(req.body.password),
+  };
+  const user = await usersService.createUser(dto);
+  res.status(201).json(user);
+}
+
+export async function me(req: AuthRequest, res: Response) {
+  const user = await usersService.getById(req.user!.id);
+  res.json(user);
 }

--- a/backend/src/modules/auth/auth.routes.ts
+++ b/backend/src/modules/auth/auth.routes.ts
@@ -1,9 +1,12 @@
 import { Router } from "express";
 import { asyncHandler as ah } from "../../lib/asyncHandler";
 import * as ctrl from "./auth.controller";
+import { authMiddleware } from "../../lib/auth";
 
 const router = Router();
 
 router.post("/login", ah(ctrl.login));
+router.post("/register", ah(ctrl.register));
+router.get("/me", authMiddleware, ah(ctrl.me));
 
 export default router;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,10 @@
   },
   "dependencies": {
     "@reduxjs/toolkit": "^2.8.2",
+    "@mui/material": "^6.1.7",
+    "@emotion/react": "^11.13.3",
+    "@emotion/styled": "^11.13.0",
+    "@react-spring/web": "^9.7.3",
     "next": "15.5.0",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -1,0 +1,10 @@
+import { Typography } from '@mui/material';
+import Protected from '@/shared/ui/Protected';
+
+export default function AdminPage() {
+  return (
+    <Protected roles={['admin']}>
+      <Typography variant="h4">Admin Panel</Typography>
+    </Protected>
+  );
+}

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,0 +1,22 @@
+import { Typography } from '@mui/material';
+import Protected from '@/shared/ui/Protected';
+import { useAppSelector } from '@/store/hooks';
+import { useSpring, animated } from '@react-spring/web';
+
+function DashboardContent() {
+  const user = useAppSelector((s) => s.auth.user)!;
+  const styles = useSpring({ from: { opacity: 0, y: -20 }, to: { opacity: 1, y: 0 } });
+  return (
+    <animated.div style={styles}>
+      <Typography variant="h4">Welcome {user.name} {user.surname}</Typography>
+    </animated.div>
+  );
+}
+
+export default function DashboardPage() {
+  return (
+    <Protected>
+      <DashboardContent />
+    </Protected>
+  );
+}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,0 +1,5 @@
+import LoginForm from '@/features/auth/ui/LoginForm';
+
+export default function LoginPage() {
+  return <LoginForm />;
+}

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -1,0 +1,5 @@
+import RegisterForm from '@/features/auth/ui/RegisterForm';
+
+export default function RegisterPage() {
+  return <RegisterForm />;
+}

--- a/frontend/src/entities/user/types.ts
+++ b/frontend/src/entities/user/types.ts
@@ -1,5 +1,7 @@
 export interface User {
   id: number;
   name: string;
+  surname: string;
   email: string;
+  role: string;
 }

--- a/frontend/src/features/auth/api/authApi.ts
+++ b/frontend/src/features/auth/api/authApi.ts
@@ -1,0 +1,37 @@
+import { createApi } from '@reduxjs/toolkit/query/react';
+import { baseQuery } from '@/shared/api/baseQuery';
+import type { User } from '@/entities/user/types';
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface RegisterRequest {
+  name: string;
+  surname: string;
+  email: string;
+  password: string;
+}
+
+export interface AuthResponse {
+  token: string;
+}
+
+export const authApi = createApi({
+  reducerPath: 'authApi',
+  baseQuery,
+  endpoints: (build) => ({
+    login: build.mutation<AuthResponse, LoginRequest>({
+      query: (body) => ({ url: '/auth/login', method: 'POST', body }),
+    }),
+    register: build.mutation<User, RegisterRequest>({
+      query: (body) => ({ url: '/auth/register', method: 'POST', body }),
+    }),
+    me: build.query<User, void>({
+      query: () => ({ url: '/auth/me' }),
+    }),
+  }),
+});
+
+export const { useLoginMutation, useRegisterMutation, useMeQuery } = authApi;

--- a/frontend/src/features/auth/model/authSlice.ts
+++ b/frontend/src/features/auth/model/authSlice.ts
@@ -1,0 +1,32 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { User } from '@/entities/user/types';
+
+interface AuthState {
+  token: string | null;
+  user: User | null;
+}
+
+const initialState: AuthState = {
+  token: null,
+  user: null,
+};
+
+const authSlice = createSlice({
+  name: 'auth',
+  initialState,
+  reducers: {
+    setCredentials(state, action: PayloadAction<{ token: string }>) {
+      state.token = action.payload.token;
+    },
+    setUser(state, action: PayloadAction<User>) {
+      state.user = action.payload;
+    },
+    logout(state) {
+      state.token = null;
+      state.user = null;
+    },
+  },
+});
+
+export const { setCredentials, setUser, logout } = authSlice.actions;
+export default authSlice.reducer;

--- a/frontend/src/features/auth/ui/LoginForm.tsx
+++ b/frontend/src/features/auth/ui/LoginForm.tsx
@@ -1,0 +1,45 @@
+'use client';
+import { useState } from 'react';
+import { Box, Button, TextField, Typography } from '@mui/material';
+import { useLoginMutation, authApi } from '../api/authApi';
+import { useAppDispatch } from '@/store/hooks';
+import { setCredentials, setUser } from '../model/authSlice';
+import { useRouter } from 'next/navigation';
+import { useSpring, animated } from '@react-spring/web';
+
+const encode = (s: string) => (typeof window === 'undefined' ? Buffer.from(s).toString('base64') : btoa(s));
+
+export default function LoginForm() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [login, { isLoading }] = useLoginMutation();
+  const dispatch = useAppDispatch();
+  const router = useRouter();
+  const styles = useSpring({ from: { opacity: 0, y: -20 }, to: { opacity: 1, y: 0 } });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const body = { email: encode(email), password: encode(password) };
+    try {
+      const { token } = await login(body).unwrap();
+      localStorage.setItem('token', token);
+      dispatch(setCredentials({ token }));
+      const user = await dispatch(authApi.endpoints.me.initiate()).unwrap();
+      dispatch(setUser(user));
+      router.push('/dashboard');
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <animated.div style={styles}>
+      <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', flexDirection: 'column', gap: 2, width: 300, mx: 'auto', mt: 4 }}>
+        <Typography variant="h5">Login</Typography>
+        <TextField label="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
+        <TextField label="Password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+        <Button type="submit" variant="contained" disabled={isLoading}>Login</Button>
+      </Box>
+    </animated.div>
+  );
+}

--- a/frontend/src/features/auth/ui/RegisterForm.tsx
+++ b/frontend/src/features/auth/ui/RegisterForm.tsx
@@ -1,0 +1,47 @@
+'use client';
+import { useState } from 'react';
+import { Box, Button, TextField, Typography } from '@mui/material';
+import { useRegisterMutation } from '../api/authApi';
+import { useRouter } from 'next/navigation';
+import { useSpring, animated } from '@react-spring/web';
+
+const encode = (s: string) => (typeof window === 'undefined' ? Buffer.from(s).toString('base64') : btoa(s));
+
+export default function RegisterForm() {
+  const [name, setName] = useState('');
+  const [surname, setSurname] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [register, { isLoading }] = useRegisterMutation();
+  const router = useRouter();
+  const styles = useSpring({ from: { opacity: 0, y: -20 }, to: { opacity: 1, y: 0 } });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const body = {
+      name: encode(name),
+      surname: encode(surname),
+      email: encode(email),
+      password: encode(password),
+    };
+    try {
+      await register(body).unwrap();
+      router.push('/login');
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <animated.div style={styles}>
+      <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', flexDirection: 'column', gap: 2, width: 300, mx: 'auto', mt: 4 }}>
+        <Typography variant="h5">Register</Typography>
+        <TextField label="Name" value={name} onChange={(e) => setName(e.target.value)} />
+        <TextField label="Surname" value={surname} onChange={(e) => setSurname(e.target.value)} />
+        <TextField label="Email" value={email} onChange={(e) => setEmail(e.target.value)} />
+        <TextField label="Password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+        <Button type="submit" variant="contained" disabled={isLoading}>Register</Button>
+      </Box>
+    </animated.div>
+  );
+}

--- a/frontend/src/shared/ui/Protected.tsx
+++ b/frontend/src/shared/ui/Protected.tsx
@@ -1,0 +1,24 @@
+'use client';
+import { ReactNode, useEffect } from 'react';
+import { useAppSelector } from '@/store/hooks';
+import { useRouter } from 'next/navigation';
+
+interface Props {
+  roles?: string[];
+  children: ReactNode;
+}
+
+export default function Protected({ roles, children }: Props) {
+  const user = useAppSelector((s) => s.auth.user);
+  const router = useRouter();
+  useEffect(() => {
+    if (!user) {
+      router.replace('/login');
+    } else if (roles && !roles.includes(user.role)) {
+      router.replace('/dashboard');
+    }
+  }, [user, roles, router]);
+  if (!user) return null;
+  if (roles && !roles.includes(user.role)) return null;
+  return <>{children}</>;
+}

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,14 +1,18 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { usersApi } from '@/features/users/api/usersApi';
 import usersReducer from '@/features/users/model/usersSlice';
+import { authApi } from '@/features/auth/api/authApi';
+import authReducer from '@/features/auth/model/authSlice';
 
 export const makeStore = () =>
   configureStore({
     reducer: {
+      auth: authReducer,
       users: usersReducer,
       [usersApi.reducerPath]: usersApi.reducer,
+      [authApi.reducerPath]: authApi.reducer,
     },
-    middleware: (gDM) => gDM().concat(usersApi.middleware),
+    middleware: (gDM) => gDM().concat(usersApi.middleware, authApi.middleware),
   });
 
 export type AppStore = ReturnType<typeof makeStore>;


### PR DESCRIPTION
## Summary
- add base64 aware login/register/me endpoints
- add frontend auth flow with MUI forms and react-spring animation
- protect client routes by user roles and greet signed-in user

## Testing
- `npm run build` (backend)
- `npm run build` (frontend) *(fails: process stalled and was interrupted)*


------
https://chatgpt.com/codex/tasks/task_e_68ad97717b9c8320833f15ab73c7d1d2