### PR TITLE
Remove Base64 encoding from auth flow

### DIFF
--- a/backend/src/modules/auth/auth.controller.ts
+++ b/backend/src/modules/auth/auth.controller.ts
@@ -3,23 +3,19 @@ import * as service from "./auth.service";
 import * as usersService from "../users/user.service";
 import { AuthRequest } from "../../lib/auth";
 
-function fromBase64(str: string) {
-  return Buffer.from(str, "base64").toString("utf-8");
-}
-
 export async function login(req: Request, res: Response) {
-  const email = fromBase64(req.body.email);
-  const password = fromBase64(req.body.password);
+  const email = req.body.email;
+  const password = req.body.password;
   const result = await service.login(email, password);
   res.json(result);
 }
 
 export async function register(req: Request, res: Response) {
   const dto = {
-    name: fromBase64(req.body.name),
-    surname: fromBase64(req.body.surname),
-    email: fromBase64(req.body.email),
-    password: fromBase64(req.body.password),
+    name: req.body.name,
+    surname: req.body.surname,
+    email: req.body.email,
+    password: req.body.password,
   };
   const user = await usersService.createUser(dto);
   res.status(201).json(user);

--- a/frontend/src/features/auth/ui/LoginForm.tsx
+++ b/frontend/src/features/auth/ui/LoginForm.tsx
@@ -7,8 +7,6 @@ import { setCredentials, setUser } from '../model/authSlice';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useSpring, animated } from '@react-spring/web';
 
-const encode = (s: string) => (typeof window === 'undefined' ? Buffer.from(s).toString('base64') : btoa(s));
-
 export default function LoginForm() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -20,7 +18,7 @@ export default function LoginForm() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const body = { email: encode(email), password: encode(password) };
+    const body = { email, password };
     try {
       const { token } = await login(body).unwrap();
       localStorage.setItem('token', token);

--- a/frontend/src/features/auth/ui/RegisterForm.tsx
+++ b/frontend/src/features/auth/ui/RegisterForm.tsx
@@ -5,8 +5,6 @@ import { useRegisterMutation } from '../api/authApi';
 import { useRouter } from 'next/navigation';
 import { useSpring, animated } from '@react-spring/web';
 
-const encode = (s: string) => (typeof window === 'undefined' ? Buffer.from(s).toString('base64') : btoa(s));
-
 export default function RegisterForm() {
   const [name, setName] = useState('');
   const [surname, setSurname] = useState('');
@@ -19,10 +17,10 @@ export default function RegisterForm() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const body = {
-      name: encode(name),
-      surname: encode(surname),
-      email: encode(email),
-      password: encode(password),
+      name,
+      surname,
+      email,
+      password,
     };
     try {
       await register(body).unwrap();


### PR DESCRIPTION
## Summary
- drop Base64 decoding in backend auth controller
- send raw credentials in frontend login and registration forms

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ada9978c7c83208d1bd7a24d17d076