### PR TITLE
feat: add swagger docs

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,12 +16,14 @@
         "express": "^4.19.2",
         "jsonwebtoken": "^9.0.2",
         "knex": "^3.1.0",
-        "pg": "^8.12.0"
+        "pg": "^8.12.0",
+        "swagger-ui-express": "^5.0.1"
       },
       "devDependencies": {
         "@types/bcryptjs": "^2.4.6",
         "@types/express": "^4.17.21",
         "@types/jsonwebtoken": "^9.0.10",
+        "@types/swagger-ui-express": "^4.1.8",
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.4.5"
@@ -67,6 +69,13 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
@@ -250,6 +259,17 @@
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -1971,6 +1991,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.27.1.tgz",
+      "integrity": "sha512-oGtpYO3lnoaqyGtlJalvryl7TwzgRuxpOVWqEHx8af0YXI+Kt+4jMpLdgMtMcmWmuQ0QTCHLKExwrBFMSxvAUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/tarn": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,12 +17,14 @@
     "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2",
     "knex": "^3.1.0",
-    "pg": "^8.12.0"
+    "pg": "^8.12.0",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.10",
+    "@types/swagger-ui-express": "^4.1.8",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.4.5"

--- a/backend/src/config/swagger.ts
+++ b/backend/src/config/swagger.ts
@@ -1,0 +1,229 @@
+const swaggerDocument = {
+  openapi: "3.0.0",
+  info: {
+    title: "E-Learning API",
+    version: "1.0.0",
+  },
+  servers: [{ url: "/api" }],
+  components: {
+    securitySchemes: {
+      bearerAuth: {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "JWT",
+      },
+    },
+    schemas: {
+      User: {
+        type: "object",
+        properties: {
+          id: { type: "integer", example: 1 },
+          name: { type: "string", example: "Ivan" },
+          surname: { type: "string", example: "Ivanov" },
+          email: { type: "string", format: "email", example: "user@example.com" },
+        },
+      },
+      LoginRequest: {
+        type: "object",
+        required: ["email", "password"],
+        properties: {
+          email: { type: "string", format: "email" },
+          password: { type: "string", format: "password" },
+        },
+      },
+      RegisterRequest: {
+        type: "object",
+        required: ["name", "surname", "email", "password"],
+        properties: {
+          name: { type: "string" },
+          surname: { type: "string" },
+          email: { type: "string", format: "email" },
+          password: { type: "string", format: "password" },
+        },
+      },
+    },
+  },
+  paths: {
+    "/auth/login": {
+      post: {
+        tags: ["auth"],
+        summary: "Authenticate user and return token",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/LoginRequest" },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "JWT token",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    token: { type: "string" },
+                  },
+                },
+              },
+            },
+          },
+          "401": { description: "Invalid credentials" },
+        },
+      },
+    },
+    "/auth/register": {
+      post: {
+        tags: ["auth"],
+        summary: "Register a new user",
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/RegisterRequest" },
+            },
+          },
+        },
+        responses: {
+          "201": {
+            description: "Created user",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/User" },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/auth/me": {
+      get: {
+        tags: ["auth"],
+        summary: "Return current user profile",
+        security: [{ bearerAuth: [] }],
+        responses: {
+          "200": {
+            description: "User profile",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/User" },
+              },
+            },
+          },
+          "401": { description: "Unauthorized" },
+        },
+      },
+    },
+    "/users": {
+      get: {
+        tags: ["users"],
+        summary: "List users",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          { name: "limit", in: "query", schema: { type: "integer", default: 20 } },
+          { name: "offset", in: "query", schema: { type: "integer", default: 0 } },
+        ],
+        responses: {
+          "200": {
+            description: "Array of users",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/User" },
+                },
+              },
+            },
+          },
+        },
+      },
+      post: {
+        tags: ["users"],
+        summary: "Create user",
+        security: [{ bearerAuth: [] }],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/RegisterRequest" },
+            },
+          },
+        },
+        responses: {
+          "201": {
+            description: "Created user",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/User" },
+              },
+            },
+          },
+          "400": { description: "Invalid data" },
+        },
+      },
+    },
+    "/users/{id}": {
+      get: {
+        tags: ["users"],
+        summary: "Get user by id",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "integer" } },
+        ],
+        responses: {
+          "200": {
+            description: "User",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/User" },
+              },
+            },
+          },
+          "404": { description: "Not found" },
+        },
+      },
+      put: {
+        tags: ["users"],
+        summary: "Update user",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "integer" } },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/RegisterRequest" },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "Updated user",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/User" },
+              },
+            },
+          },
+          "404": { description: "Not found" },
+        },
+      },
+      delete: {
+        tags: ["users"],
+        summary: "Delete user",
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "integer" } },
+        ],
+        responses: {
+          "204": { description: "Deleted successfully" },
+        },
+      },
+    },
+  },
+};
+
+export default swaggerDocument;

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,6 +5,8 @@ import usersRouter from "./modules/users/user.routes";
 import authRouter from "./modules/auth/auth.routes";
 import { knex } from "./db/knex";
 import cors from "cors";
+import swaggerUi from "swagger-ui-express";
+import swaggerDocument from "./config/swagger";
 dotenv.config({ path: path.resolve(__dirname, "../.env") });
 
 const app = express();
@@ -15,6 +17,7 @@ app.use(
     credentials: true,
   })
 );
+app.use("/docs", swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 // health + проверка коннекта к БД
 app.get("/health", async (_req, res, next) => {
   try {


### PR DESCRIPTION
## Summary
- add swagger-ui-express and types
- document auth and user endpoints with OpenAPI schema
- expose swagger UI at `/docs`

## Testing
- `cd backend && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68adadb8c5848320be60c55c53c2fa77